### PR TITLE
Fix to_visual algorithm broken after first call

### DIFF
--- a/lib/bidi/weakhashmap.rb
+++ b/lib/bidi/weakhashmap.rb
@@ -33,10 +33,10 @@ class WeakHashMap
     ref=@internalHash[key]
     return nil unless ref
     GC.disable
-    unless ref.weakref_alive? {
+    unless ref.weakref_alive?
       GC.enable
       return nil
-    }
+    end
 
     ret_value = ref.__getobj__.value
     GC.enable
@@ -48,6 +48,4 @@ class WeakHashMap
        @internalHash.delete key
     end
   end
-end
-
 end


### PR DESCRIPTION
Hey thanks for making ruby-bidi!
Let me know if there's anything else you need from me in order to get this into your next bidi gem release.
- Julian

Commit message below:

This change fixes an issue where to_visual was only returning the
correctly formatted bidi result the first time it was called after a
server restart (or anything else that would re-initialize Bidi’s global
$weakHashMap variable).

The root cause of this issue was an unless block with improper syntax.
Ruby doesn’t allow braces to be used to define multi-line unless
blocks. Instead, the ‘end’ keyword must be used. This caused the ruby
interpreter to think that the end of the WeakHashMap’s [] method
definition was the real end of the offending unless block. Due to this,
on any WeakHashMap ‘hit’ the code that actually assigns ret_value was
always skipped and the delete method definition was returned instead.
This caused every letter to have bidiType nil in bidi.rb’s
to_paragraphs method which messed up the bidi algorithm.

This is also the reason why an extra end keyword was previously needed
at the bottom of the file. Were it not there, a SyntaxError would have
been raised.

I manually tested this change by testing that to_visual returned the
correctly formatted bidi string on its first, second, and subsequent
calls, without restarting my rails server, using the input string "משפט עם עברית ו-English. מספרים: 12345 (וגם כל מיני סימני פיסוק) וגם סימן קריאה!” taken from this thread
https://github.com/prawnpdf/prawn/issues/514
